### PR TITLE
Improve POM to support incremental compilation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.7</java.version>
         <scala.base.version>2.10</scala.base.version>
         <scala.version>${scala.base.version}.4</scala.version>
         <cdh.version>-cdh5.3.0</cdh.version>
@@ -17,10 +18,17 @@
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
             <version>${scala.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>algebird-core_${scala.base.version}</artifactId>
@@ -45,23 +53,42 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                
+                <configuration>
+                    <recompileMode>incremental</recompileMode>
+                    <useZincServer>true</useZincServer>
+                </configuration>
+
                 <executions>
                     <execution>
-                        <id>compile</id>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <phase>compile</phase>
                     </execution>
                     <execution>
-                        <id>test-compile</id>
+                        <id>scala-test-compile-first</id>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>testCompile</goal>
                         </goals>
-                        <phase>test-compile</phase>
                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+
+                <executions>
                     <execution>
-                        <phase>process-resources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
@@ -80,7 +107,7 @@
                         </goals>
                         <configuration>
                             <minimizeJar>true</minimizeJar>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.hadoop.hbase</pattern>


### PR DESCRIPTION
Here are the main changes:

* The code is now incrementally compiled. You have to explicitly use `<recompileMode>incremental</recompileMode>` for _scala-maven-plugin_.
* If Zinc compilation server is listening on the local machine it is used, providing faster compilation. I had to use `<useZincServer>true</useZincServer>` for _scala-maven-plugin_.
* I configured executions as _scala-maven-plugin_ recommends for mixed Java/Scala compilation. Spark project's POM has the configuration. I also added the plugin for the Java compiler, that is _maven-compiler-plugin_.
* I corrected some warnings.